### PR TITLE
Change timeline_flash to respect "no-osc" preferences in input.conf

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -303,6 +303,8 @@ local state = {
 }
 local forced_key_bindings -- defined at the bottom next to events
 
+local no_osd_l_max = 0 -- maximum seek length for which timeline_flash is suppressed
+
 -- HELPERS
 
 function round(number)
@@ -2167,7 +2169,7 @@ elements:add('timeline', Element.new({
 				if position and state.position then
 					local seek_length = math.abs(position - state.position)
 					-- Don't flash on video looping (seek to 0) or tiny seeks (frame-step)
-					if position > 0.5 and seek_length > 0.5 then this:flash() end
+					if position > 0.5 and seek_length > (no_osd_l_max+0.5) then this:flash() end
 				end
 			end)
 		end
@@ -2666,6 +2668,20 @@ state.context_menu_items = (function()
 				end
 			end
 		end
+
+		-- look into input.conf for preferences about flashing the osd on seek events
+		if not string.match(line, '#.*') then
+			local no_osd_l_str = string.match(line, '.*no%-osd.*seek +[ %-](%d+).*')
+			if no_osd_l_str ~= nil then
+				local no_osd_l = tonumber(no_osd_l_str)
+				if no_osd_l > no_osd_l_max then
+					no_osd_l_max = no_osd_l
+				end
+			end
+		end
+		-- if input.conf doesn't have any no-osd seek entries, then no_osd_l_max is left at 0.
+		-- 0.5 will still be added afterwards to correct for single frame differences between requested seek and performed seek. 
+
 	end
 
 	if #items > 0 then return items end


### PR DESCRIPTION
First of all thank you for the very nice and useful script.

I found the `timeline_flash` option in `uosc.conf` a little limiting compared to mpv's default options.  In `input.conf`, it is possible to add the `no-osd` prefix to each individual seek command to not flash the timeline.

Since the script already looks into `input.conf`, I added a couple lines to detect the command with the **highest** absolute value seek that is marked with `no-osd`. Then I set the timeline flash to activate only for seeks longer than that value.

In general this doesn't fully respect the user's preferences, unless their input.conf looks like this:
```
RIGHT no-osd seek  5
LEFT  no-osd seek -5

CTRL+RIGHT seek 10
CTRL+LEFT seek -10
```
where all the "short" seeks are marked with `no-osd` and the longer ones aren't, and there is no difference between positive and negative seeks. However I'd say this is a fairly normal approach and I'd expect the vast majority of people to be fine with this.

Feel free to change anything you don't like, or even to ignore the request if you find a better solution.