### PR TITLE
Fix crash when using --image-display-duration

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -1365,7 +1365,7 @@ end
 -- ELEMENT RENDERERS
 
 function render_timeline(this)
-	if this.size_max == 0 or state.duration == nil or state.position == nil then return end
+	if this.size_max == 0 or state.duration == nil or state.duration == 0 or state.position == nil then return end
 
 	local size_min = this:get_effective_size_min()
 	local size = this:get_effective_size()


### PR DESCRIPTION
There is apparently no way to get the current position, so disabling the bar like the script currently does for images.