### PR TITLE
Don't add minus sign to end time when using total_time

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -1553,13 +1553,13 @@ function render_timeline(this)
 			ass:append(ass_opacity(math.min(options.timeline_opacity + 0.1, 1), text_opacity))
 			ass:pos(display.width - spacing, fay + (size / 2))
 			ass:an(6)
-			ass:append('-'..end_time)
+			ass:append((options.total_time and '' or '-')..end_time)
 			ass:new_event()
 			ass:append('{\\blur0\\bord0\\shad1\\1c&H'..options.color_background_text..'\\4c&H'..options.color_background..'\\fn'..config.font..'\\fs'..this.font_size..bold_tag..'\\iclip('..foreground_coordinates..')')
 			ass:append(ass_opacity(math.min(options.timeline_opacity + 0.1, 1), text_opacity))
 			ass:pos(display.width - spacing, fay + (size / 2))
 			ass:an(6)
-			ass:append('-'..end_time)
+			ass:append((options.total_time and '' or '-')..end_time)
 		end
 	end
 


### PR DESCRIPTION
With `total_time=yes`, end time is absolute. There shouldn't be a minus sign.