### PR TITLE
changed chapter_ranges config + sponscrub support

### DIFF
--- a/uosc.conf
+++ b/uosc.conf
@@ -134,8 +134,16 @@ font_height_to_letter_width_ratio=0.5
 # chapter_ranges=^op| op$|opening<968638:0.5>.*, ^ed| ed$|^end|ending$<968638:0.5>.*|{eof}
 # ```
 #
-# Display skippable youtube video sponsor blocks from https://github.com/po5/mpv_sponsorblock
+# Display in red skippable youtube video sponsor segments marked by https://github.com/po5/mpv_sponsorblock (streaming),
+# https://github.com/faissaloo/SponSkrub (file-modifying) or https://github.com/yt-dlp/SponSkrub (downloading):
 # ```
-# chapter_ranges=sponsor start<3535a5:.5>sponsor end, segment start<3535a5:0.5>segment end
+# chapter_ranges=Sponsor segment start<3535a5:0.5>Sponsor segment end, sponskrub%-sponsor<3535a5:0.5>.*
 # ```
-chapter_ranges=^op| op$|opening<968638:0.5>.*, ^ed| ed$|^end|ending$<968638:0.5>.*|{eof}, sponsor start<3535a5:.5>sponsor end, segment start<3535a5:0.5>segment end
+#
+# Display all segments that sponsorblock marks in the default colors of the browser plug-in:
+# ```
+# chapter_ranges=sponskrub%-sponsor<007800:0.5>.*,Sponsor segment start<007800:0.5>Sponsor segment end,sponskrub%-intro<808000:0.5>.*,Intro segment start<808000:0.5>Intro segment end,sponskrub%-outro<700000:0.5>.*,Outro segment start<700000:0.5>Outro segment end,sponskrub%-interaction<87006c:0.5>.*,Interaction segment start<87006c:0.5>Interaction segment end,sponskrub%-selfpromo<35bfbf:0.5>.*,Selfpromo segment start<35bfbf:0.5>Selfpromo segment end,sponskrub%-music%_offtopic<4a63a6:0.5>.*
+# ```
+#
+# Default ranges:
+chapter_ranges=^op| op$|opening<968638:0.5>.*, ^ed| ed$|^end|ending$<968638:0.5>.*|{eof}, Sponsor segment start<3535a5:0.5>Sponsor segment end, sponskrub%-sponsor<3535a5:0.5>.*


### PR DESCRIPTION
Changed displayed sponsorblock segments to only include the sponsor segments. However, also included option to display all segments that sponsorblock marks in the default colors of the browser plug-in.

Added support for sponscrub markers.

I think it makes more sense to only display the actual sponsor segments by default and then give the user the option to display all other segments, but in different colors.