### PR TITLE
Add menu button widget

### DIFF
--- a/uosc.conf
+++ b/uosc.conf
@@ -52,6 +52,13 @@ menu_hjkl_navigation=no
 menu_opacity=0.8
 menu_font_scale=1
 
+# menu button widget
+menu_button=no
+menu_button_size=40
+menu_button_size_fullscreen=50
+menu_button_opacity=0.5
+menu_button_border=1
+
 # top bar with window controls and media title
 # can be: never, no-border, always
 top_bar=no-border


### PR DESCRIPTION
I added an optional button where uosc's menu appears, so as to have the menu be consistent with the other UI components being mouse-accessible by proximity alone.

Personally, I have as old habit to use mpv's defaults of `mbtn_right cycle pause` and `mbtn_left ignore`, leaving it like that since not all my keyboards have a menu key, so the switch to uosc's suggested example has been awkward. Initially, I wrote this as a separate script to call `script-binding uosc/menu` when clicked in roughly the same area, but I liked it so much that I felt a visual indicator was worth making, and that also let the clickable area be smaller.
