### PR TITLE
Fix delete-file-next; add flash-top-bar command; allow '#menu:' as keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Adding items to menu is facilitated by commenting your keybinds in `input.conf` 
 
 Comment has to be at the end of the line with the binding.
 
-Comment has to start with `#!`.
+Comment has to start with `#!` (or `#menu:`).
 
 Text after `#!` is an item title.
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ Expands the bottom timeline until pressed again, or next mouse move. Useful to c
 Toggles the always visible portion of the timeline. You can look at it as switching `timeline_size_min` option between it's configured value and 0.
 
 #### `flash-timeline`
+#### `flash-top-bar`
 #### `flash-volume`
 #### `flash-speed`
 #### `flash-pause-indicator`
@@ -265,6 +266,8 @@ down         add volume -10; script-binding uosc/flash-volume
 [            add speed -0.25; script-binding uosc/flash-speed
 ]            add speed  0.25; script-binding uosc/flash-speed
 \            set speed 1; script-binding uosc/flash-speed
+>            script-binding uosc/next; script-binding flash-top-bar; script-binding flash-timeline
+<            script-binding uosc/prev; script-binding flash-top-bar; script-binding flash-timeline
 ```
 
 Case for `(flash/decide)-pause-indicator`: mpv handles frame stepping forward by briefly resuming the video, which causes pause indicator to flash, and none likes that when they are trying to compare frames. The solution is to enable manual pause indicator (`pause_indicator=manual`) and use `flash-pause-indicator` (for a brief flash) or `decide-pause-indicator` (for a static indicator) as a secondary command to all bindings you wish would display it (see space binding example above).

--- a/uosc.lua
+++ b/uosc.lua
@@ -2825,6 +2825,9 @@ state.context_menu_items = (function()
 
 	for line in io.lines(input_conf_path) do
 		local key, command, title = string.match(line, '%s*([%S]+)%s+(.*)%s#!%s*(.*)')
+		if not key then
+			key, command, title = string.match(line, '%s*([%S]+)%s+(.*)%s#menu:%s*(.*)')
+		end
 		if key then
 			local is_dummy = key:sub(1, 1) == '#'
 			local submenu_id = ''

--- a/uosc.lua
+++ b/uosc.lua
@@ -179,6 +179,7 @@ Available keybindings (place into `input.conf`):
 Key  script-binding uosc/peek-timeline
 Key  script-binding uosc/toggle-progress
 Key  script-binding uosc/flash-timeline
+Key  script-binding uosc/flash-top-bar
 Key  script-binding uosc/flash-volume
 Key  script-binding uosc/flash-speed
 Key  script-binding uosc/flash-pause-indicator
@@ -3244,6 +3245,9 @@ mp.add_key_binding(nil, 'toggle-progress', function()
 end)
 mp.add_key_binding(nil, 'flash-timeline', function()
 	elements.timeline:flash()
+end)
+mp.add_key_binding(nil, 'flash-top-bar', function()
+	elements.top_bar:flash()
 end)
 mp.add_key_binding(nil, 'flash-volume', function()
 	if elements.volume then elements.volume:flash() end

--- a/uosc.lua
+++ b/uosc.lua
@@ -3520,10 +3520,6 @@ mp.add_key_binding(nil, 'last-file', function() load_file_in_current_directory(-
 mp.add_key_binding(nil, 'delete-file-next', function()
 	local playlist_count = mp.get_property_native('playlist-count')
 
-	if playlist_count > 1 then
-		mp.commandv('playlist-remove', 'current')
-	end
-
 	local next_file = nil
 
 	local path = mp.get_property_native('path')
@@ -3532,17 +3528,23 @@ mp.add_key_binding(nil, 'delete-file-next', function()
 	if is_local_file then
 		path = normalize_path(path)
 
-		next_file = get_adjacent_file(path, 'forward', options.media_types)
-
 		if menu:is_open('open-file') then
 			elements.menu:delete_value(path)
 		end
 	end
 
-	if next_file then
-		mp.commandv('loadfile', next_file)
+	if playlist_count > 1 then
+		mp.commandv('playlist-remove', 'current')
 	else
-		mp.commandv('stop')
+		if is_local_file then
+			next_file = get_adjacent_file(path, 'forward', options.media_types)
+		end
+		
+		if next_file then
+			mp.commandv('loadfile', next_file)
+		else
+			mp.commandv('stop')
+		end
 	end
 
 	if is_local_file then delete_file(path) end


### PR DESCRIPTION
Thanks for this awesome mpv script. Here are some very small improvement suggestions:

[keep playlist on delete-file-next command](https://github.com/darsain/uosc/commit/0005120302085f518e11d14e68d06e6f0d038e38):
This is actually a bug fix. Before when using the delete-file-next binding in a playlist, it would just skip to the next file in the folder and disregard the playlist. Now it moves to the next file in the playlist as it is described in the readme.

[add flash-top-bar command](https://github.com/darsain/uosc/commit/f237f70bcefa8bf7251f2202b8947703596e4092):
Adds another flash binding, just like the other ones. I found it very helpful to flash the top bar when using a "next" shortcut, to see the file title.

[Also allow '#menu:' as keyword instead of '#!' in input.conf](https://github.com/darsain/uosc/commit/5f80046b393222fb6321b4b087fd93749ccdd3c8):
This adds only one if statement and is useful for more compatibility with mpv.NET, which uses the input.conf to build a context menu just like uosc.

