### PR TITLE
Consistant scrolling direction

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -2387,10 +2387,10 @@ elements:add('timeline', Element.new({
 		if this.pressed then this:set_from_cursor() end
 	end,
 	on_wheel_up = function(this)
-		if options.timeline_step > 0 then mp.commandv('seek', -options.timeline_step) end
+		mp.commandv('seek', -options.timeline_step)
 	end,
 	on_wheel_down = function(this)
-		if options.timeline_step > 0 then mp.commandv('seek', options.timeline_step) end
+		mp.commandv('seek', options.timeline_step)
 	end,
 	render = render_timeline,
 }))

--- a/uosc.lua
+++ b/uosc.lua
@@ -2387,10 +2387,10 @@ elements:add('timeline', Element.new({
 		if this.pressed then this:set_from_cursor() end
 	end,
 	on_wheel_up = function(this)
-		mp.commandv('seek', -options.timeline_step)
+		mp.commandv('seek', options.timeline_step)
 	end,
 	on_wheel_down = function(this)
-		mp.commandv('seek', options.timeline_step)
+		mp.commandv('seek', -options.timeline_step)
 	end,
 	render = render_timeline,
 }))
@@ -2664,10 +2664,10 @@ if options.speed then
 			request_render()
 		end,
 		on_wheel_up = function(this)
-			mp.set_property_native('speed', state.speed - options.speed_step)
+			mp.set_property_native('speed', state.speed + options.speed_step)
 		end,
 		on_wheel_down = function(this)
-			mp.set_property_native('speed', state.speed + options.speed_step)
+			mp.set_property_native('speed', state.speed - options.speed_step)
 		end,
 		render = render_speed,
 	}))


### PR DESCRIPTION
Scrolling up to change a value is semantically associated with
increasing that value.
Volume already worked this way, and the same is true for seeking
by scrolling outside of the UI, but scrolling up on the timeline
seeked backwards and scrolling up on the speed widget reduced speed.
Now scrolling on the timeline or outside of the UI seeks in the same
direction and speed also increases when scrolling up on the widget.
The restriction of only allowing positive numbers for `timeline_step`
has also been lifted, allowing users to set negative numbers
if they want to reverse the scrolling direction of timeline seeking.
This was already possible for speed and volume.