### PR TITLE
Render on cache updates

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -3152,6 +3152,7 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 	end
 	local cache_ranges = cache_state['seekable-ranges']
 	state.cached_ranges = #cache_ranges > 0 and cache_ranges or nil
+	request_render()
 end)
 
 -- CONTROLS


### PR DESCRIPTION
The updated state of the cache was not visible when the player was
paused and not interacted with.

Now a render is requested on every cache update, which happens roughly
two times per second for me.

Due to my slow internet connection I often have a video buffering on one monitor while I'm doing something on the other one. Having to mouse over to see how far it has buffered was annoying.