### PR TITLE
Automatically choose rendering frequency

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -302,7 +302,9 @@ local options = {
 }
 opt.read_options(options, 'uosc')
 local config = {
-	render_delay = 0.03, -- sets max rendering frequency
+	-- sets max rendering frequency in case the
+	-- native rendering frequency could not be detected
+	render_delay = 1/60,
 	font = mp.get_property('options/osd-font'),
 	menu_parent_opacity = 0.4,
 	menu_min_width = 260
@@ -348,6 +350,7 @@ local state = {
 	end),
 	mouse_bindings_enabled = false,
 	cached_ranges = nil,
+	render_delay = config.render_delay,
 }
 local forced_key_bindings -- defined at the bottom next to events
 
@@ -2172,7 +2175,7 @@ function request_render()
 
 	if not state.render_timer:is_enabled() then
 		local now = mp.get_time()
-		local timeout = config.render_delay - (now - state.render_last_time)
+		local timeout = state.render_delay - (now - state.render_last_time)
 		if timeout < 0 then
 			timeout = 0
 		end
@@ -2962,6 +2965,20 @@ function load_file_in_current_directory(index)
 	end
 end
 
+function update_render_delay(name, fps)
+	if fps then
+		state.render_delay = 1/fps
+	end
+end
+
+function observe_display_fps(name, fps)
+	if fps then
+		mp.unobserve_property(update_render_delay)
+		mp.unobserve_property(observe_display_fps)
+		mp.observe_property('display-fps', 'native', update_render_delay)
+	end
+end
+
 -- MENUS
 
 function create_select_tracklist_type_menu_opener(menu_title, track_type, track_prop)
@@ -3153,6 +3170,8 @@ mp.observe_property('demuxer-cache-state', 'native', function(prop, cache_state)
 	local cache_ranges = cache_state['seekable-ranges']
 	state.cached_ranges = #cache_ranges > 0 and cache_ranges or nil
 end)
+mp.observe_property('display-fps', 'native', observe_display_fps)
+mp.observe_property('estimated-display-fps', 'native', update_render_delay)
 
 -- CONTROLS
 


### PR DESCRIPTION
I think there is slightly less jitter with `display-fps` then with `estimated-display-fps`, although it's really hard to tell and I don't have multiple monitors with different refresh rates to test with.
Simply swap them around if you want to try it yourself.

I've also noticed that `estimated-display-fps` does not get updated when the video is paused, so when there was a low estimated fps because of e.g. heavy background activity, then the refresh rate during pause will also be low. This could be worked around by adding `state.pause and` in front of it.