### PR TITLE
Fix speed dial crash

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -2649,9 +2649,6 @@ if options.speed then
 			end
 		end,
 		on_global_mbtn_left_up = function(this)
-			if this.dragging and elements.timeline.proximity_raw == 0 then
-				this:fadeout()
-			end
 			this.dragging = nil
 			request_render()
 		end,


### PR DESCRIPTION
When dragging the speed dial and letting go over the timeline,
`this:fadeout` was called, but that function does not exist.
Introduced in 755194352f6eacb3488fd519be6ecbc21137463d

I think this was simply forgotten in the aforementioned commit.

Closes #78