### PR TITLE
Fix menu crash when quickly repeatedly opening and closing submenu

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -1068,7 +1068,7 @@ function Menu:open(items, open_item, opts)
 					elements:add('menu', transition_target)
 				end
 				menu.transition = nil
-				transition_target:back()
+				if transition_target then transition_target:back() end
 				return
 			else
 				menu.transition = {to = 'parent', target = this.parent_menu}
@@ -1100,7 +1100,7 @@ function Menu:open(items, open_item, opts)
 				local target = menu.transition.target
 				tween_element_stop(target)
 				menu.transition = nil
-				target:open_selected_item(soft)
+				if target then target:open_selected_item(soft) end
 				return
 			end
 


### PR DESCRIPTION
Opening and closing a submenu very quickly very quickly (smashing right and left arrow as fast as I possibly can) resulted in a nil error.

The error occurred in line 1103 and after adding a nil check it would result in a nil error in line 1071 instead, so I added a nil check there as well.

While testing I also managed to end up with an unresponsive menu two times. Closing and reopening fixes the problem, so much less problematic then the interface crashing. It's also really hard to reproduce. I don't know if that problem was introduced by my changes here or if it already existed before and I would just end up with a nil crash before that ever happened.

It's not a nice solution, but I couldn't find the root cause of the problem (at least not without spending hours searching for it).