### PR TITLE
Menu width configuration

### DIFF
--- a/uosc.conf
+++ b/uosc.conf
@@ -48,9 +48,12 @@ speed_font_scale=1
 # controls all menus, such as context menu, subtitle loader/selector, etc
 menu_item_height=36
 menu_item_height_fullscreen=50
+menu_min_width=260
+menu_min_width_fullscreen=360
 menu_wasd_navigation=no
 menu_hjkl_navigation=no
 menu_opacity=0.8
+menu_parent_opacity=0.4
 menu_font_scale=1
 
 # menu button widget

--- a/uosc.lua
+++ b/uosc.lua
@@ -69,9 +69,12 @@ speed_font_scale=1
 # controls all menus, such as context menu, subtitle loader/selector, etc
 menu_item_height=36
 menu_item_height_fullscreen=50
+menu_min_width=260
+menu_min_width_fullscreen=360
 menu_wasd_navigation=no
 menu_hjkl_navigation=no
 menu_opacity=0.8
+menu_parent_opacity=0.4
 menu_font_scale=1
 
 # menu button widget
@@ -262,9 +265,12 @@ local options = {
 
 	menu_item_height = 36,
 	menu_item_height_fullscreen = 50,
+	menu_min_width = 260,
+	menu_min_width_fullscreen = 360,
 	menu_wasd_navigation = false,
 	menu_hjkl_navigation = false,
 	menu_opacity = 0.8,
+	menu_parent_opacity = 0.4,
 	menu_font_scale = 1,
 
 	menu_button = 'never',
@@ -312,8 +318,6 @@ local config = {
 	-- native rendering frequency could not be detected
 	render_delay = 1/60,
 	font = mp.get_property('options/osd-font'),
-	menu_parent_opacity = 0.4,
-	menu_min_width = 260
 }
 local bold_tag = options.font_bold and '\\b1' or ''
 local display = {
@@ -1032,7 +1036,7 @@ function Menu:open(items, open_item, opts)
 			tween_element(menu.transition.target, 0, 1, function(_, pos)
 				this:set_offset_x(round(start_offset * (1 - pos)))
 				this.opacity = pos
-				this:set_parent_opacity(1 - ((1 - config.menu_parent_opacity) * pos))
+				this:set_parent_opacity(1 - ((1 - options.menu_parent_opacity) * pos))
 			end, function()
 				menu.transition = nil
 				update_proximities()
@@ -1070,7 +1074,8 @@ function Menu:open(items, open_item, opts)
 			-- Coordinates and sizes are of the scrollable area to make
 			-- consuming values in rendering easier. Title drawn above this, so
 			-- we need to account for that in max_height and ay position.
-			this.width = round(math.min(math.max(estimated_max_width, config.menu_min_width), display.width * 0.9))
+			local min_width = state.fullormaxed and options.menu_min_width_fullscreen or options.menu_min_width
+			this.width = round(math.min(math.max(estimated_max_width, min_width), display.width * 0.9))
 			local title_height = this.title and this.scroll_step or 0
 			local max_height = round(display.height * 0.9) - title_height
 			this.height = math.min(round(this.scroll_step * #this.items) - this.item_spacing, max_height)
@@ -1112,13 +1117,13 @@ function Menu:open(items, open_item, opts)
 		fadeout = function(this, callback)
 			this:tween(1, 0, function(this, pos)
 				this.opacity = pos
-				this:set_parent_opacity(pos * config.menu_parent_opacity)
+				this:set_parent_opacity(pos * options.menu_parent_opacity)
 			end, callback)
 		end,
 		set_parent_opacity = function(this, opacity)
 			if this.parent_menu then
 				this.parent_menu.opacity = opacity
-				this.parent_menu:set_parent_opacity(opacity * config.menu_parent_opacity)
+				this.parent_menu:set_parent_opacity(opacity * options.menu_parent_opacity)
 			end
 		end,
 		get_item_index_below_cursor = function(this)
@@ -1210,7 +1215,7 @@ function Menu:open(items, open_item, opts)
 			tween_element(target, 0, 1, function(_, pos)
 				this:set_offset_x(round(to_offset * pos))
 				this.opacity = 1 - pos
-				this:set_parent_opacity(config.menu_parent_opacity + ((1 - config.menu_parent_opacity) * pos))
+				this:set_parent_opacity(options.menu_parent_opacity + ((1 - options.menu_parent_opacity) * pos))
 			end, function()
 				menu.transition = nil
 				elements:add('menu', target)

--- a/uosc.lua
+++ b/uosc.lua
@@ -1056,8 +1056,12 @@ function Menu:open(items, open_item, opts)
 			local estimated_max_width = 0
 			for _, item in ipairs(this.items) do
 				local spacings_in_item = item.hint and 3 or 2
+				local has_submenu = item.items ~= nil
+				-- M as a stand in for icon
+				local hint_icon = item.hint or (has_submenu and 'M' or nil)
+				local hint_icon_size = item.hint and this.font_size_hint or this.font_size
 				local estimated_width = text_width_estimate(item.title, this.font_size)
-				                        + text_width_estimate(item.hint, this.font_size_hint)
+				                        + text_width_estimate(hint_icon, hint_icon_size)
 				                        + (this.item_content_spacing * spacings_in_item)
 				if estimated_width > estimated_max_width then
 					estimated_max_width = estimated_width


### PR DESCRIPTION
I was wondering why the menu _appears_ wider when windowed then when in fullscreen.
Turns out they actually were the same width `menu_min_width`, but in windowed it felt too wide because of the change in font size and item height. I made the width configurable and introduced a new one for fullscreen that is roughly 1.4 times the size of the windowed width, because item height and font size also change by that factor when in fullscreen.

While trying out different minimum widths, one of the entries with a submenu got clipped by the submenu icon.
Turns out that icon was not considered during the width estimation.

Now people can make their menu as narrow as the text allows.

I personally prefer
```
menu_min_width=185
menu_min_width_fullscreen=260
```
but I left the default for windowed the way it was.