### PR TITLE
Menu offset and dimensions update

### DIFF
--- a/uosc.lua
+++ b/uosc.lua
@@ -1080,6 +1080,9 @@ function Menu:open(items, open_item, opts)
 			this.bx = round(this.ax + this.width)
 			this.by = round(this.ay + this.height)
 
+			-- Update offsets for new sizes
+			this:set_offset_x(this.offset_x)
+
 			if this.parent_menu then
 				this.parent_menu:on_display_change()
 			end

--- a/uosc.lua
+++ b/uosc.lua
@@ -1020,6 +1020,7 @@ function Menu:open(items, open_item, opts)
 			end
 
 			-- Set initial dimensions
+			this:update_dimensions()
 			this:on_display_change()
 
 			-- Scroll to selected item
@@ -1041,7 +1042,7 @@ function Menu:open(items, open_item, opts)
 		destroy = function(this)
 			request_render()
 		end,
-		on_display_change = function(this)
+		update_dimensions = function(this)
 			this.item_height = state.fullormaxed and options.menu_item_height_fullscreen or options.menu_item_height
 			this.font_size = round(this.item_height * 0.48 * options.menu_font_scale)
 			this.font_size_hint = this.font_size - 1
@@ -1075,13 +1076,20 @@ function Menu:open(items, open_item, opts)
 			local max_height = round(display.height * 0.9) - title_height
 			this.height = math.min(round(this.scroll_step * #this.items) - this.item_spacing, max_height)
 			this.scroll_height = math.max((this.scroll_step * #this.items) - this.height - this.item_spacing, 0)
+
+			-- Update offsets for new sizes
+			this:set_offset_x(this.offset_x)
+
+			if this.parent_menu then
+				this.parent_menu:update_dimensions()
+			end
+		end,
+		on_display_change = function(this)
+			local title_height = this.title and this.scroll_step or 0
 			this.ax = round((display.width - this.width) / 2) + this.offset_x
 			this.ay = round((display.height - this.height) / 2 + (title_height / 2))
 			this.bx = round(this.ax + this.width)
 			this.by = round(this.ay + this.height)
-
-			-- Update offsets for new sizes
-			this:set_offset_x(this.offset_x)
 
 			if this.parent_menu then
 				this.parent_menu:on_display_change()
@@ -1093,6 +1101,7 @@ function Menu:open(items, open_item, opts)
 			end
 
 			-- Trigger changes and re-render
+			this:update_dimensions()
 			this:on_display_change()
 
 			-- Reset indexes and scroll
@@ -1167,6 +1176,7 @@ function Menu:open(items, open_item, opts)
 			if (index and index >= 1 and index <= #this.items) then
 				local previous_active_value = this.active_index and this.items[this.active_index].value or nil
 				table.remove(this.items, index)
+				this:update_dimensions()
 				this:on_display_change()
 				if previous_active_value then this:activate_value(previous_active_value) end
 				this:scroll_to_item(this.selected_item)
@@ -1247,6 +1257,7 @@ function Menu:open(items, open_item, opts)
 		end,
 		open_selected_item_soft = function(this) this:open_selected_item(true) end,
 		close = function(this) menu:close() end,
+		on_prop_fullormaxed = function(this) this:update_dimensions() end,
 		on_global_mbtn_left_down = function(this)
 			if this.proximity_raw == 0 then
 				this.selected_item = this:get_item_index_below_cursor()


### PR DESCRIPTION
Menu offset would not get updated when the width changed, leading to things like this when entering/leaving fullscreen (or maximize):
![screenshot_menu_before](https://user-images.githubusercontent.com/8932183/185019413-67ae5f7b-df2b-4b76-a63b-89515e7a0063.png)
(I set the min width to 100 for that screenshot so that the width actually changes when full screened)

Now it behaves correctly.
The dimensions of the menu now also only get updated when necessary.