### PR TITLE
Add speed_bar_offset option

### DIFF
--- a/uosc.conf
+++ b/uosc.conf
@@ -48,6 +48,7 @@ volume_font_scale=1
 speed=no
 speed_size=46
 speed_size_fullscreen=68
+speed_bar_offset=0
 speed_persistency=
 speed_opacity=1
 speed_step=0.1

--- a/uosc.lua
+++ b/uosc.lua
@@ -48,6 +48,7 @@ local options = {
 	speed = false,
 	speed_size = 46,
 	speed_size_fullscreen = 60,
+	speed_bar_offset=0,
 	speed_persistency = '',
 	speed_opacity = 1,
 	speed_step = 0.1,
@@ -2634,7 +2635,8 @@ if options.speed then
 			this.notch_spacing = this.width / this.notches
 			this.ax = (display.width - this.width) / 2
 			this.by = display.height - elements.window_border.size - elements.timeline.size_max - elements.timeline.top_border
-			this.ay = this.by - this.height
+			this.ay = this.by - options.speed_bar_offset / 100 * display.height - this.height
+			this.by = this.ay + this.height
 			this.bx = this.ax + this.width
 			this.font_size = round(this.height * 0.48 * options.speed_font_scale)
 		end,

--- a/uosc.lua
+++ b/uosc.lua
@@ -2623,11 +2623,9 @@ if options.speed then
 		notch_every = 0.1,
 		font_size = nil,
 		get_effective_proximity = function(this)
-			if elements.timeline.proximity_raw == 0 then return 0 end
 			if is_element_persistent('speed') then return 1 end
 			if this.forced_proximity then return this.forced_proximity end
-			local timeline_proximity = elements.timeline.forced_proximity or elements.timeline.proximity
-			return this.forced_proximity or math[cursor.hidden and 'min' or 'max'](this.proximity, timeline_proximity)
+			return this.forced_proximity or this.proximity
 		end,
 		update_dimensions = function(this)
 			this.height = state.fullormaxed and options.speed_size_fullscreen or options.speed_size


### PR DESCRIPTION
Lets the user reposition the speed bar (e.g. `speed_bar_offset=82` to display it closer to the top bar).